### PR TITLE
Added vLLM support for Qwen 2.5 VL models

### DIFF
--- a/core/dist/providers/index.js
+++ b/core/dist/providers/index.js
@@ -4,6 +4,7 @@ exports.getModel = void 0;
 const openAI_1 = require("./openAI");
 const ollama_1 = require("./ollama");
 const google_1 = require("./google");
+const vllm_1 = require("./vllm");
 const types_1 = require("../types");
 class getModel {
     static getProviderForModel(model) {
@@ -15,6 +16,9 @@ class getModel {
         }
         if (Object.values(types_1.LocalModels).includes(model)) {
             return new ollama_1.Ollama();
+        }
+        if (Object.values(types_1.VLLMModels).includes(model)) {
+            return new vllm_1.VLLM();
         }
         throw new Error(`No provider found for model "${model}"`);
     }

--- a/core/dist/providers/vllm.d.ts
+++ b/core/dist/providers/vllm.d.ts
@@ -1,0 +1,5 @@
+import { Completion } from "./utils/completion";
+import { CompletionArgs, CompletionResponse } from "../types";
+export declare class VLLM implements Completion {
+    getCompletion(args: CompletionArgs): Promise<CompletionResponse>;
+}

--- a/core/dist/providers/vllm.js
+++ b/core/dist/providers/vllm.js
@@ -1,0 +1,71 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.VLLM = void 0;
+const axios_1 = __importDefault(require("axios"));
+const types_1 = require("../types");
+const utils_1 = require("../utils");
+class VLLM {
+    async getCompletion(args) {
+        const { imagePath, llmParams, maintainFormat, model, priorPage, } = args;
+        const baseUrl = process.env.BASE_URL;
+        if (!baseUrl) {
+            throw new Error("Missing BASE_URL in environment variables.");
+        }
+        if (!process.env.OPENAI_API_KEY) {
+            throw new Error("Missing OPENAI_API_KEY in environment variables.");
+        }
+        const apiKey = process.env.OPENAI_API_KEY;
+        const validModels = Object.values(types_1.OpenAIModels);
+        if (!validModels.includes(model)) {
+            throw new Error(`Model "${model}" is not an OpenAI model.`);
+        }
+        const systemPrompt = `
+    Convert the following image/document  to markdown. 
+    Return only the markdown with no explanation text. Do not include deliminators like '''markdown.
+    You must include all information on the page. Do not exclude headers, footers, or subtext.
+  `;
+        const messages = [{ role: "system", content: systemPrompt }];
+        if (maintainFormat && priorPage) {
+            messages.push({
+                role: "system",
+                content: `Please ensure markdown formatting remains consistent with the prior page:\n\n"""${priorPage}"""`,
+            });
+        }
+        const base64Image = await (0, utils_1.encodeImageToBase64)(imagePath);
+        messages.push({
+            role: "user",
+            content: [
+                {
+                    type: "image_url",
+                    image_url: { url: `data:image/png;base64,${base64Image}` },
+                },
+            ],
+        });
+        try {
+            const response = await axios_1.default.post(`${baseUrl}/chat/completions`, {
+                messages,
+                model,
+                ...(0, utils_1.convertKeysToSnakeCase)(llmParams ?? null),
+            }, {
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+            });
+            const data = response.data;
+            return {
+                content: data.choices[0].message.content,
+                inputTokens: data.usage?.prompt_tokens ?? 0,
+                outputTokens: data.usage?.completion_tokens ?? 0,
+            };
+        }
+        catch (err) {
+            console.error("OpenAI error:", err);
+            throw err;
+        }
+    }
+}
+exports.VLLM = VLLM;

--- a/core/dist/types.d.ts
+++ b/core/dist/types.d.ts
@@ -4,6 +4,10 @@ export declare enum OpenAIModels {
     GPT_4_1 = "gpt-4.1",
     GPT_4_1_MINI = "gpt-4.1-mini"
 }
+export declare enum VLLMModels {
+    QWEN_2_5_3B_Instruct = "Qwen/Qwen2.5-VL-3B-Instruct",
+    QWEN_2_5_72B_Instruct = "Qwen/Qwen2.5-VL-72B-Instruct"
+}
 export declare enum LocalModels {
     LLAMA3_2_VISION = "llama3.2-vision"
 }
@@ -14,7 +18,7 @@ export declare enum GoogleModels {
     GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b",
     GEMINI_1_5_PRO = "gemini-1.5-pro"
 }
-export type ModelOptions = OpenAIModels | GoogleModels | LocalModels;
+export type ModelOptions = OpenAIModels | GoogleModels | LocalModels | VLLMModels;
 export interface DocumindArgs {
     cleanup?: boolean;
     concurrency?: number;

--- a/core/dist/types.js
+++ b/core/dist/types.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.GoogleModels = exports.LocalModels = exports.OpenAIModels = void 0;
+exports.GoogleModels = exports.LocalModels = exports.VLLMModels = exports.OpenAIModels = void 0;
 var OpenAIModels;
 (function (OpenAIModels) {
     OpenAIModels["GPT_4O"] = "gpt-4o";
@@ -8,6 +8,11 @@ var OpenAIModels;
     OpenAIModels["GPT_4_1"] = "gpt-4.1";
     OpenAIModels["GPT_4_1_MINI"] = "gpt-4.1-mini";
 })(OpenAIModels || (exports.OpenAIModels = OpenAIModels = {}));
+var VLLMModels;
+(function (VLLMModels) {
+    VLLMModels["QWEN_2_5_3B_Instruct"] = "Qwen/Qwen2.5-VL-3B-Instruct";
+    VLLMModels["QWEN_2_5_72B_Instruct"] = "Qwen/Qwen2.5-VL-72B-Instruct";
+})(VLLMModels || (exports.VLLMModels = VLLMModels = {}));
 var LocalModels;
 (function (LocalModels) {
     //LLAVA = "llava",

--- a/core/src/providers/index.ts
+++ b/core/src/providers/index.ts
@@ -2,7 +2,8 @@ import { Completion } from "./utils/completion";
 import { OpenAI } from "./openAI";
 import { Ollama } from "./ollama";
 import { Google } from "./google";
-import { ModelOptions, OpenAIModels, LocalModels, GoogleModels } from "../types";
+import { VLLM } from "./vllm"
+import { ModelOptions, OpenAIModels, LocalModels, GoogleModels, VLLMModels } from "../types";
 
 export class getModel {
   public static getProviderForModel(model: ModelOptions): Completion {
@@ -14,6 +15,9 @@ export class getModel {
     }
     if (Object.values(LocalModels).includes(model as LocalModels)) {
       return new Ollama();
+    }
+    if (Object.values(VLLMModels).includes(model as VLLMModels)) {
+      return new VLLM();
     }
 
     throw new Error(`No provider found for model "${model}"`);

--- a/core/src/providers/vllm.ts
+++ b/core/src/providers/vllm.ts
@@ -1,0 +1,83 @@
+import axios from "axios";
+import { Completion } from "./utils/completion";
+import { CompletionArgs, CompletionResponse, OpenAIModels } from "../types";
+import { convertKeysToSnakeCase, encodeImageToBase64 } from "../utils";
+
+export class VLLM implements Completion {
+  public async getCompletion(args: CompletionArgs): Promise<CompletionResponse> {
+    const {
+      imagePath,
+      llmParams,
+      maintainFormat,
+      model,
+      priorPage,
+    } = args;
+
+    const baseUrl = process.env.BASE_URL;
+    if (!baseUrl) {
+      throw new Error("Missing BASE_URL in environment variables.");
+    }
+    if (!process.env.OPENAI_API_KEY) {
+      throw new Error("Missing OPENAI_API_KEY in environment variables.");
+    }
+    const apiKey = process.env.OPENAI_API_KEY;
+
+    const validModels = Object.values(OpenAIModels); 
+    if (!validModels.includes(model as OpenAIModels)) {
+      throw new Error(`Model "${model}" is not an OpenAI model.`);
+    }
+
+    const systemPrompt = `
+    Convert the following image/document  to markdown. 
+    Return only the markdown with no explanation text. Do not include deliminators like '''markdown.
+    You must include all information on the page. Do not exclude headers, footers, or subtext.
+  `;
+
+    const messages: any = [{ role: "system", content: systemPrompt }];
+
+    if (maintainFormat && priorPage) {
+      messages.push({
+        role: "system",
+        content: `Please ensure markdown formatting remains consistent with the prior page:\n\n"""${priorPage}"""`,
+      });
+    }
+
+    const base64Image = await encodeImageToBase64(imagePath);
+    messages.push({
+      role: "user",
+      content: [
+        {
+          type: "image_url",
+          image_url: { url: `data:image/png;base64,${base64Image}` },
+        },
+      ],
+    });
+
+    try {
+      const response = await axios.post(
+        `${baseUrl}/chat/completions`,
+        {
+          messages,
+          model,
+          ...convertKeysToSnakeCase(llmParams ?? null),
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const data = response.data;
+      return {
+        content: data.choices[0].message.content,
+        inputTokens: data.usage?.prompt_tokens ?? 0,
+        outputTokens: data.usage?.completion_tokens ?? 0,
+      };
+    } catch (err) {
+      console.error("OpenAI error:", err);
+      throw err;
+    }
+  }
+}

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -5,6 +5,11 @@ export enum OpenAIModels {
   GPT_4_1_MINI = "gpt-4.1-mini",
 }
 
+export enum VLLMModels {
+  QWEN_2_5_3B_Instruct = "Qwen/Qwen2.5-VL-3B-Instruct",
+  QWEN_2_5_72B_Instruct = "Qwen/Qwen2.5-VL-72B-Instruct",
+}
+
 export enum LocalModels {
   //LLAVA = "llava",
   LLAMA3_2_VISION = "llama3.2-vision",
@@ -18,7 +23,7 @@ export enum GoogleModels {
   GEMINI_1_5_PRO = "gemini-1.5-pro",
 }
 
-export type ModelOptions = OpenAIModels | GoogleModels | LocalModels;
+export type ModelOptions = OpenAIModels | GoogleModels | LocalModels | VLLMModels;
 
 export interface DocumindArgs {
   cleanup?: boolean;

--- a/extractor/src/extractors/vllm.js
+++ b/extractor/src/extractors/vllm.js
@@ -1,0 +1,31 @@
+import OpenAI from "openai";
+import { zodResponseFormat } from "openai/helpers/zod";
+
+export const openAIExtractor = async ({ markdown, zodSchema, prompt, model }) => {
+  if (!process.env.BASE_URL) {
+    throw new Error("Missing BASE_URL");
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error("Missing OPENAI_API_KEY");
+  }
+
+  const openai = new OpenAI({
+    baseURL:process.env.BASE_URL,
+    apiKey:process.env.OPENAI_API_KEY
+  });
+  
+  const vllmModel = model;
+
+  const completion = await openai.beta.chat.completions.parse({
+    model: vllmModel,
+    messages: [
+      { role: "system", content: prompt },
+      { role: "user", content: markdown },
+    ],
+    response_format: zodResponseFormat(zodSchema, "event"),
+  });
+
+  const event = completion.choices[0].message.parsed;
+  return event;
+}


### PR DESCRIPTION
I want to test the library but I could run models on my laptop

I usually test on RunPod where they offer vLLM in their serverless solutions [(even contributed)](https://github.com/runpod-workers/worker-vllm/pull/143)

For that reason I added vLLM support for the package